### PR TITLE
Add section on alternate ribbon cable assemblies

### DIFF
--- a/PREFACE.md
+++ b/PREFACE.md
@@ -18,7 +18,7 @@ consideration for the viewer's learning experience as John's Basement.
 Before you even have the supplies you need to get started, you really should
 join the Z80 Retro! Discord Server, introduce yourself, and join the community.
 
-Here are some photos of my build showing the Z80-Retro! with the VDP duaghter board.
+Here are some photos of my build showing the Z80-Retro! with the VDP daughter board.
 
 ![gallery01](./assets/PXL_20230402_044401816.jpg)
 

--- a/Z80-RETRO-ALTERNATE-PARTS.md
+++ b/Z80-RETRO-ALTERNATE-PARTS.md
@@ -38,3 +38,28 @@ is:
         that this device can not be programmed with the Raspberry PI Programmer
         adapter board: [2065-Z80-programmer](https://github.com/Z80-Retro/2065-Z80-programmer)
 
+## Ribbon Cables
+
+The [2063-Z80 README](https://github.com/Z80-Retro/2063-Z80) document lists some
+sources for DIY Ribbon Cable assembly.  Should you prefer to purchase premade
+parts, here are some links current (as at 2024-06-29).  Should these links ever
+die, we have tried to provide valid search terms to find similar replacement
+items.
+
+Unfortunately, it's hard to tell from Amazon or Ebay listings what the pin
+mappings are.  These two specific links have been tested and reported to be
+known good and working by one of our community members in Discord.
+
+There is some configurability available through the J1 and J8 jumpber blocks on
+the 2063-Z80 board which allow for reassignment some of the rx and tx pins.
+Check the schematic carefully.
+
+- Serial Port Cables:
+    DB9 RS232 Serial Female to 10 Pin Female Ribbon Cable Connector Adapter
+    2.54mm Pitch 30cm Length
+    Length [https://www.amazon.com/dp/B07Q2WCJZF?th=1](https://www.amazon.com/dp/B07Q2WCJZF?th=1)
+
+- Printer Cable:
+    uxcell IDC Wire Flat Ribbon Cable DB25 Female to FC-26 Female Connector 
+    2.54mm Pitch 20cm Length, 2pcs [https://www.amazon.com/dp/B07SC1KJ5K](https://www.amazon.com/dp/B07SC1KJ5K)
+

--- a/Z80-RETRO-BUILD.md
+++ b/Z80-RETRO-BUILD.md
@@ -8,30 +8,38 @@ into the intricacies of surface mount soldering techniques.
 That said, here are some tips:
 
 - Videos:
-  - _Video Link: [Z80 Retro #33 - v4rc1 Full Build and Test pt. 1](https://youtu.be/X0ApysAFA7k)_
-  - _Video Link: [Z80 Retro #34 - v4rc1 Full Build and Test pt. 2](https://youtu.be/aZyimz6YkGY)_
+  - _Video Link: [Z80 Retro #33 - v4rc1 Full Build and Test pt.
+    1](https://youtu.be/X0ApysAFA7k)_
+  - _Video Link: [Z80 Retro #34 - v4rc1 Full Build and Test pt.
+    2](https://youtu.be/aZyimz6YkGY)_
 
 - Use good quality, machined sockets for the full can oscillators.
 - Watch out when ordering the resistors.  They need to be the 1/8 watt type.
-They are very small.  The more common 1/4 watt type will not fit well on the
-board.  You can make them work, but it's gonna be messy.
+  They are very small.  The more common 1/4 watt type will not fit well on the
+  board.  You can make them work, but it's gonna be messy.
 - If you're struggling with the surface mounted SD Card socket, have a look at
-the Sparkfun breakout board option.
+  the Sparkfun breakout board option.
+- An alternative to soldering the SMD parts with a soldering iron is to use
+  solder paste and a hot air gun.  If you have a hot air rework station, we have
+  had reports of success with *#4 Sn42Bi58 138C* paste which can be found on
+  Amazon.  You want the low melting point stuff which will make it easier to
+  heat the board up sufficiently for the paste to begin flowing.
 - Some people even use sockets for the resistor networks.  This does raise them
-up slightly but as resistor networks are more expensive, you might want to
-consider using a socket for them too.
+  up slightly but as resistor networks are more expensive, you might want to
+  consider using a socket for them too.
 - Use ceramic MLCC Capacitors for the un-polarised capacitors.  An assortment
-can be purchased from [Amazon](https://www.amazon.com/ceramic-capacitor-kit/s?k=ceramic+capacitor+kit).
-Don't use tantalum capacitors like I did in the RS232 circuit.  While they do
-work, they are polarised so care should be taken to install them correctly and
-they are sensitive to voltage spikes and the risk of them popping is high.
-**DON'T USE THEM.**
-They are censored in the image below.  - See [ICL3232CPZ Capacitors](#icl3232cpz-capacitors)
-for an example of how they should be installed.
+  can be purchased from
+  [Amazon](https://www.amazon.com/ceramic-capacitor-kit/s?k=ceramic+capacitor+kit).
+  Don't use tantalum capacitors like I did in the RS232 circuit.  While they do
+  work, they are polarised so care should be taken to install them correctly and
+  they are sensitive to voltage spikes and the risk of them popping is high.
+  **DON'T USE THEM.** They are censored in the image below.  - See [ICL3232CPZ
+  Capacitors](#icl3232cpz-capacitors) for an example of how they should be
+  installed.
 - Make sure your oscillator cans are oriented correctly.  Pin 1 is pointed to by
-the orange arrows on the image below.
+  the orange arrows on the image below.
 - You can use the cheaper socket types for everything but the oscillator cans.
-(I used machined sockets because I am a nerd.)  It's not required.
+  (I used machined sockets because I am a nerd.)  It's not required.
 
 ## As Built CPU Board
 

--- a/Z80-RETRO-FIRMWARE.md
+++ b/Z80-RETRO-FIRMWARE.md
@@ -72,3 +72,20 @@ The manufacturer-supplied software for the XGPro runs on windows only.  There is
 an open source project on [GitLab](https://gitlab.com/DavidGriffith/minipro) that
 you can clone, build and use to program your chips.  Follow the usage
 instructions in that repository.
+
+These instructions for the minipro tool on Linux are given and assume a working
+minipro installation.
+
+```bash
+$ minipro -s -p SST39SF020A -w 2063-Z80-cpm/boot/firmware.bin
+Found TL866CS 03.2.86 (0x256)
+Device code: 54416913
+Serial code: 58CD45F94BB765B9A1DF15A9
+Chip ID: 0xBFB6 OK
+Warning: Incorrect file size: 2463 (needed 262144)
+Erasing... 0.40Sec OK
+Writing Code... 0.19Sec OK
+Reading Code... 0.03Sec OK
+Verification OK
+```
+


### PR DESCRIPTION
Add section on alternate ribbon cable assemblies. 

Reviewers - click here to see the new section rendered. https://github.com/linuxplayground/Z80-Retro-Manual/blob/alternate-ribbon-cables/Z80-RETRO-ALTERNATE-PARTS.md