### PR TITLE
Do Not Populate guidance, SparkFun SDCard Breakout Board

### DIFF
--- a/Z80-RETRO-BUILD.md
+++ b/Z80-RETRO-BUILD.md
@@ -90,14 +90,14 @@ regulator underneath the board.
 
 List of Do Not Populate when _ONLY USING_ the SparkFun Breakout board.
 
-- J10 - SDCard socket
+- J2  - SDCard socket
 - R1  - R6 - Resistor divider network
 - R7  - MISO Pull-up resistor
 - C17 - Bypass Capacitor
 - U20 - Voltage regulator 5v down to 3.3v
 - C18, C19, C24 - Capacitors required by the voltage regulator.
 
-If you ever choose to populate the J10 SDCard socket, then you should also
+If you ever choose to populate the J2 SDCard socket, then you should also
 populate all the other related components from the above list.  You never know
 who, in the future, will be using your board and they might want to use that
 socket if it's present on the board.

--- a/Z80-RETRO-BUILD.md
+++ b/Z80-RETRO-BUILD.md
@@ -84,6 +84,10 @@ The J10 connector is designed to accept a SparkFun Level Shifting microSD
 Breakout board.  This board will take care of level shifting between 5v and the
 3.3v required for the SDCard.
 
+There is no problem with populating all the components which would allow for
+using either the on-board SDCard socket (J2) _or_ the SparkFun breakout board.
+(J10).  You can _not_ use both at the same time.
+
 If your intention is to _NEVER USE_ the surface mounted J2 SDCard socket, then
 you don't need to populate the resistor divider network or the voltage
 regulator underneath the board.

--- a/Z80-RETRO-BUILD.md
+++ b/Z80-RETRO-BUILD.md
@@ -18,10 +18,10 @@ That said, here are some tips:
   They are very small.  The more common 1/4 watt type will not fit well on the
   board.  You can make them work, but it's gonna be messy.
 - If you're struggling with the surface mounted SD Card socket, have a look at
-  the Sparkfun breakout board option.
+  the SparkFun breakout board option. - Details in section below.
 - An alternative to soldering the SMD parts with a soldering iron is to use
   solder paste and a hot air gun.  If you have a hot air rework station, we have
-  had reports of success with *#4 Sn42Bi58 138C* paste which can be found on
+  had reports of success with _#4 Sn42Bi58 138C_ paste which can be found on
   Amazon.  You want the low melting point stuff which will make it easier to
   heat the board up sufficiently for the paste to begin flowing.
 - Some people even use sockets for the resistor networks.  This does raise them
@@ -54,7 +54,7 @@ image.
 |Silk Screen      |Function                                                     |Default Config
 |---------------- |------------------------------------------------------------ |---------------
 |J1 - CONSOLE (A) |Primary serial connection to host PC                         |TX-PIN2,RX-PIN3
-|J8 - AUX (B)     |Used for auxiliary serial connections                         |Unpopulated
+|J8 - AUX (B)     |Used for auxiliary serial connections                        |Unpopulated
 |J11 - SIO/CTC    |Set SIO or CTC as clock source for CONSOLE (A) and AUX (B)   |Both set to X2
 |J12              |Select a different bank on the Flash.                        |Unpopulated
 |J9 - USER1       |General user input.  Assigned to bit 5 on GP Input.          |Unpopulated
@@ -72,3 +72,35 @@ capacitors](./assets/z80-retro-ic3232-capcitors.jpg)
 And here is a how they look installed.  Thanks again to Bob ("The Professor").
 
 ![Cropped Closup Of ICL3232 capacitors installed](./assets/z80-retro-ic3232-asbuilt.jpg)
+
+## The Do Not Populate Resistors
+
+A future release of the board will most likely have these components removed
+from the schematic and PCB.  But for now, do not populate R15 and R16.
+
+## SparkFun SDCard Breakout Board
+
+The J10 connector is designed to accept a SparkFun Level Shifting microSD
+Breakout board.  This board will take care of level shifting between 5v and the
+3.3v required for the SDCard.
+
+If your intention is to _NEVER USE_ the surface mounted J2 SDCard socket, then
+you don't need to populate the resistor divider network or the voltage
+regulator underneath the board.
+
+List of Do Not Populate when _ONLY USING_ the SparkFun Breakout board.
+
+- J10 - SDCard socket
+- R1  - R6 - Resistor divider network
+- R7  - MISO Pull-up resistor
+- C17 - Bypass Capacitor
+- U20 - Voltage regulator 5v down to 3.3v
+- C18, C19, C24 - Capacitors required by the voltage regulator.
+
+If you ever choose to populate the J10 SDCard socket, then you should also
+populate all the other related components from the above list.  You never know
+who, in the future, will be using your board and they might want to use that
+socket if it's present on the board.
+
+- [https://www.sparkfun.com/sparkfun-level-shifting-microsd-breakout.html](https://www.sparkfun.com/sparkfun-level-shifting-microsd-breakout.html)
+- [https://www.digikey.co.nz/en/products/detail/sparkfun-electronics/DEV-13743/5881845](https://www.digikey.co.nz/en/products/detail/sparkfun-electronics/DEV-13743/5881845)

--- a/Z80-RETRO-EMULATOR.md
+++ b/Z80-RETRO-EMULATOR.md
@@ -87,6 +87,9 @@ $ sudo losetup --all | grep SDcard
 /dev/loop12: [2050]:7215475 (/home/davelatham/dev/retro/2063-Z80-cpm/filesystem/SDcard.img)
 ```
 
+The Loopback Device Setup tool `losetup` can be found here:
+[https://man7.org/linux/man-pages/man8/losetup.8.html](https://man7.org/linux/man-pages/man8/losetup.8.html)
+
 In my case here, the loopback device is `/dev/loop12` so that's what I will use.
 You must use the device name your system reports.
 

--- a/Z80-RETRO-INSTALL-CPM.md
+++ b/Z80-RETRO-INSTALL-CPM.md
@@ -148,7 +148,7 @@ Copy `drive.img` to your partitioned SD Card using the dd command.
 
 ```bash
 $ cd 2063-Z80-cpm
-$ sudo dd if=filesystem/drive.img of=/dev/sdd1 bs=512 conv=sync
+$ sudo dd if=filesystem/drive.img of=/dev/sdd1 bs=512 conv=fsync
 ```
 
 Now eject your SD Card and try it out on the Retro.

--- a/pandoc_template/metadata.md
+++ b/pandoc_template/metadata.md
@@ -1,7 +1,7 @@
 ---
 title: "Z80-Retro! Manual"
 author: David Latham, K3130440 (Tim)
-date: "2024-07-15"
+date: "2025-04-17"
 header-includes: |
     \usepackage{sectsty}
     \sectionfont{\clearpage}


### PR DESCRIPTION
This PR provides additional details in the build instructions regarding Do Not Populate R15 and R16 along with some guidance on what to do when only using the SparkFun breakout board.

You can review the rendered Markdown here: https://github.com/linuxplayground/Z80-Retro-Manual/blob/sdcard-bob-updates/Z80-RETRO-BUILD.md#the-do-not-populate-resistors

Addresses Issues:

- https://github.com/Z80-Retro/Z80-Retro-Manual/issues/17
- https://github.com/Z80-Retro/Z80-Retro-Manual/issues/18